### PR TITLE
Fix unclosed divs in account-fixed page

### DIFF
--- a/client/src/pages/account-fixed.tsx
+++ b/client/src/pages/account-fixed.tsx
@@ -421,6 +421,8 @@ export default function AccountPage() {
               </div>
             </div>
           </div>
+        </div>
+      </div>
 
       {/* Main Content - Adjusted margin to account for sidebar */}
       <div className="ml-72 flex-1 p-8">


### PR DESCRIPTION
## Summary
- close remaining sidebar `<div>` elements in account-fixed page

## Testing
- `npm run check` *(fails: Cannot find module 'vite' and other dependencies)*