### PR TITLE
Fix substring usage in debug output

### DIFF
--- a/server/db.ts
+++ b/server/db.ts
@@ -20,7 +20,7 @@ export function initializeDatabase() {
   console.log('DATABASE_URL exists:', !!process.env.DATABASE_URL);
   console.log('DATABASE_URL length:', process.env.DATABASE_URL?.length);
   console.log('First 10 chars of DATABASE_URL:', process.env.DATABASE_URL?.substring(0, 10));
-  console.log('Last 10 chars of DATABASE_URL:', process.env.DATABASE_URL?.substring(-10));
+  console.log('Last 10 chars of DATABASE_URL:', process.env.DATABASE_URL?.slice(-10));
   console.log('===================================');
 
   if (!process.env.DATABASE_URL) {


### PR DESCRIPTION
## Summary
- fix the logic for printing the last 10 characters of `DATABASE_URL`

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*