### PR TITLE
Fix signup process routing

### DIFF
--- a/client/src/components/signup/PaymentStep.tsx
+++ b/client/src/components/signup/PaymentStep.tsx
@@ -161,7 +161,7 @@ function CheckoutForm({ onComplete }: PaymentStepProps) {
 }
 
 export function PaymentStep({ onComplete }: PaymentStepProps) {
-  useSignupGuard('SUBSCRIPTION');
+  useSignupGuard('payment');
   return (
     <Elements stripe={stripePromise}>
       <CheckoutForm onComplete={onComplete} />

--- a/client/src/components/signup/ProfileStep.tsx
+++ b/client/src/components/signup/ProfileStep.tsx
@@ -4,12 +4,10 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Loader2, Upload } from 'lucide-react';
 import { useToast } from "@/hooks/use-toast";
-import { advanceSignupStage, getSignupEmail, updateSignupProfile, getSignupData, clearSignupData } from '@/lib/signup-wizard';
+import { getSignupEmail, updateSignupProfile, clearSignupData } from '@/lib/signup-wizard';
 import { useSignupWizard } from '@/contexts/SignupWizardContext';
-import { apiRequest } from '@/lib/queryClient';
-import { useAuth } from '@/hooks/use-auth';
+import { post } from '@/lib/api';
 import { INDUSTRY_OPTIONS } from "@/lib/constants";
-import { useLocation } from 'wouter';
 import { useSignupGuard } from '@/hooks/useSignupGuard';
 
 interface ProfileStepProps {
@@ -28,7 +26,6 @@ export function ProfileStep({ onComplete }: ProfileStepProps) {
   useSignupGuard('profile');
   const { toast } = useToast();
   const { refreshStage } = useSignupWizard();
-  const { registerMutation } = useAuth();
   const [isLoading, setIsLoading] = useState(false);
   const [fullName, setFullName] = useState('');
   const [location, setLocation] = useState('');
@@ -43,8 +40,6 @@ export function ProfileStep({ onComplete }: ProfileStepProps) {
   const [avatar, setAvatar] = useState<File | null>(null);
   const [avatarPreview, setAvatarPreview] = useState<string | null>(null);
   const email = getSignupEmail();
-  const [showSuccess, setShowSuccess] = useState(false);
-  const [, navigate] = useLocation();
 
   const handleAvatarChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.target.files && e.target.files[0]) {
@@ -70,18 +65,7 @@ export function ProfileStep({ onComplete }: ProfileStepProps) {
     }
     setIsLoading(true);
     try {
-      // Gather all data from localStorage
-      const registrationData = getSignupData();
-      const agreementData = JSON.parse(localStorage.getItem('signup_agreement') || '{}');
-      const paymentData = JSON.parse(localStorage.getItem('signup_payment') || '{}');
-      if (!registrationData || !agreementData || !paymentData) {
-        throw new Error('Some signup data is missing. Please restart the signup process.');
-      }
-      // Compose the full registration payload
-      const payload = {
-        ...registrationData,
-        ...agreementData,
-        ...paymentData,
+      await updateSignupProfile(email, {
         fullName,
         location,
         title,
@@ -92,9 +76,7 @@ export function ProfileStep({ onComplete }: ProfileStepProps) {
         twitter,
         instagram,
         doFollow,
-      };
-      // Create the account
-      await registerMutation.mutateAsync(payload);
+      });
       // Optionally upload avatar
       if (avatar) {
         const formData = new FormData();
@@ -104,29 +86,19 @@ export function ProfileStep({ onComplete }: ProfileStepProps) {
           body: formData,
         });
       }
-      clearSignupData();
-      setShowSuccess(true);
+      const completeRes = await post(`/api/signup-stage/${encodeURIComponent(email)}/complete`, {});
+      if (completeRes.success) {
+        clearSignupData();
+        onComplete(completeRes.token);
+      } else {
+        throw new Error('Failed to complete signup');
+      }
     } catch (error: any) {
       toast({ title: 'Profile Update Error', description: error.message || 'There was an error updating your profile. Please try again.', variant: 'destructive' });
     }
     setIsLoading(false);
   };
 
-  if (showSuccess) {
-    return (
-      <div className="flex flex-col items-center justify-center min-h-[400px] p-8 bg-white rounded-2xl shadow-lg max-w-2xl mx-auto mt-8">
-        <div className="text-5xl mb-4">🎉</div>
-        <h2 className="text-3xl font-bold mb-2 text-center">Welcome to QuoteBid!</h2>
-        <p className="text-lg text-gray-700 mb-6 text-center">Your account has been created successfully.<br />You now have full access to the QuoteBid marketplace.</p>
-        <Button
-          className="bg-[#004684] hover:bg-[#003a70] text-white px-8 py-3 text-lg font-semibold"
-          onClick={() => navigate('/opportunities', { replace: true })}
-        >
-          Continue to Dashboard
-        </Button>
-      </div>
-    );
-  }
   
   return (
     <form onSubmit={handleSubmit} className="bg-white p-8 rounded-2xl shadow-lg max-w-4xl mx-auto mt-8">

--- a/client/src/hooks/useSignupGuard.ts
+++ b/client/src/hooks/useSignupGuard.ts
@@ -25,12 +25,16 @@ export function useSignupGuard(requiredStage: string) {
         // Map stage to step number
         const stageToStep = (stage: string) => {
           switch (stage) {
-            case 'REGISTERED': return 1;
-            case 'AGREEMENT': return 2;
-            case 'SUBSCRIPTION':
-            case 'PROFILE': return 3;
-            case 'COMPLETED': return 'dashboard';
-            default: return 1;
+            case 'agreement':
+              return 1;
+            case 'payment':
+              return 2;
+            case 'profile':
+              return 3;
+            case 'ready':
+              return 'dashboard';
+            default:
+              return 1;
           }
         };
         const step = stageToStep(data.stage);

--- a/server/routes/signupStage.ts
+++ b/server/routes/signupStage.ts
@@ -619,8 +619,8 @@ async function generateAgreementPDF(fullName: string, signature: string, signedA
   });
 }
 
-// Update signup stage
-router.patch('/api/auth/stage', async (req: Request, res: Response) => {
+// Update signup stage (not used by wizard, kept for backward compatibility)
+router.patch('/stage', async (req: Request, res: Response) => {
   const userId = req.user?.id;
   const { stage } = req.body;
   if (!userId) return res.status(401).json({ message: 'Unauthorized' });


### PR DESCRIPTION
## Summary
- add missing `/api/auth/progress` and `/api/auth/stage` routes
- clean up legacy signup-stage patch route
- make Payment step guard use `payment` stage
- rework Profile step to update profile and complete signup via API
- normalize stage names in signup guard

## Testing
- `npm run --silent check` *(fails: Cannot find type definition file for 'node')*
- `npx tsc -p tsconfig.json` *(fails: Cannot find type definition file for 'node')*