### PR TITLE
Implement stateful signup flow

### DIFF
--- a/client/src/components/signup/PaymentStep.tsx
+++ b/client/src/components/signup/PaymentStep.tsx
@@ -161,7 +161,7 @@ function CheckoutForm({ onComplete }: PaymentStepProps) {
 }
 
 export function PaymentStep({ onComplete }: PaymentStepProps) {
-  useSignupGuard('SUBSCRIPTION');
+  useSignupGuard('payment');
   return (
     <Elements stripe={stripePromise}>
       <CheckoutForm onComplete={onComplete} />

--- a/client/src/components/signup/ProfileStep.tsx
+++ b/client/src/components/signup/ProfileStep.tsx
@@ -4,12 +4,10 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Loader2, Upload } from 'lucide-react';
 import { useToast } from "@/hooks/use-toast";
-import { advanceSignupStage, getSignupEmail, updateSignupProfile, getSignupData, clearSignupData } from '@/lib/signup-wizard';
+import { getSignupEmail, updateSignupProfile, clearSignupData } from '@/lib/signup-wizard';
 import { useSignupWizard } from '@/contexts/SignupWizardContext';
-import { apiRequest } from '@/lib/queryClient';
-import { useAuth } from '@/hooks/use-auth';
+import { post } from '@/lib/api';
 import { INDUSTRY_OPTIONS } from "@/lib/constants";
-import { useLocation } from 'wouter';
 import { useSignupGuard } from '@/hooks/useSignupGuard';
 
 interface ProfileStepProps {
@@ -28,7 +26,6 @@ export function ProfileStep({ onComplete }: ProfileStepProps) {
   useSignupGuard('profile');
   const { toast } = useToast();
   const { refreshStage } = useSignupWizard();
-  const { registerMutation } = useAuth();
   const [isLoading, setIsLoading] = useState(false);
   const [fullName, setFullName] = useState('');
   const [location, setLocation] = useState('');
@@ -43,8 +40,6 @@ export function ProfileStep({ onComplete }: ProfileStepProps) {
   const [avatar, setAvatar] = useState<File | null>(null);
   const [avatarPreview, setAvatarPreview] = useState<string | null>(null);
   const email = getSignupEmail();
-  const [showSuccess, setShowSuccess] = useState(false);
-  const [, navigate] = useLocation();
 
   const handleAvatarChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.target.files && e.target.files[0]) {
@@ -70,18 +65,7 @@ export function ProfileStep({ onComplete }: ProfileStepProps) {
     }
     setIsLoading(true);
     try {
-      // Gather all data from localStorage
-      const registrationData = getSignupData();
-      const agreementData = JSON.parse(localStorage.getItem('signup_agreement') || '{}');
-      const paymentData = JSON.parse(localStorage.getItem('signup_payment') || '{}');
-      if (!registrationData || !agreementData || !paymentData) {
-        throw new Error('Some signup data is missing. Please restart the signup process.');
-      }
-      // Compose the full registration payload
-      const payload = {
-        ...registrationData,
-        ...agreementData,
-        ...paymentData,
+      await updateSignupProfile(email, {
         fullName,
         location,
         title,
@@ -92,9 +76,7 @@ export function ProfileStep({ onComplete }: ProfileStepProps) {
         twitter,
         instagram,
         doFollow,
-      };
-      // Create the account
-      await registerMutation.mutateAsync(payload);
+      });
       // Optionally upload avatar
       if (avatar) {
         const formData = new FormData();
@@ -104,29 +86,19 @@ export function ProfileStep({ onComplete }: ProfileStepProps) {
           body: formData,
         });
       }
-      clearSignupData();
-      setShowSuccess(true);
+      const completeRes = await post(`/api/signup-stage/${encodeURIComponent(email)}/complete`, {});
+      if (completeRes.success) {
+        clearSignupData();
+        onComplete(completeRes.token);
+      } else {
+        throw new Error('Failed to complete signup');
+      }
     } catch (error: any) {
       toast({ title: 'Profile Update Error', description: error.message || 'There was an error updating your profile. Please try again.', variant: 'destructive' });
     }
     setIsLoading(false);
   };
 
-  if (showSuccess) {
-    return (
-      <div className="flex flex-col items-center justify-center min-h-[400px] p-8 bg-white rounded-2xl shadow-lg max-w-2xl mx-auto mt-8">
-        <div className="text-5xl mb-4">🎉</div>
-        <h2 className="text-3xl font-bold mb-2 text-center">Welcome to QuoteBid!</h2>
-        <p className="text-lg text-gray-700 mb-6 text-center">Your account has been created successfully.<br />You now have full access to the QuoteBid marketplace.</p>
-        <Button
-          className="bg-[#004684] hover:bg-[#003a70] text-white px-8 py-3 text-lg font-semibold"
-          onClick={() => navigate('/opportunities', { replace: true })}
-        >
-          Continue to Dashboard
-        </Button>
-      </div>
-    );
-  }
   
   return (
     <form onSubmit={handleSubmit} className="bg-white p-8 rounded-2xl shadow-lg max-w-4xl mx-auto mt-8">

--- a/client/src/hooks/useSignupGuard.ts
+++ b/client/src/hooks/useSignupGuard.ts
@@ -25,12 +25,16 @@ export function useSignupGuard(requiredStage: string) {
         // Map stage to step number
         const stageToStep = (stage: string) => {
           switch (stage) {
-            case 'REGISTERED': return 1;
-            case 'AGREEMENT': return 2;
-            case 'SUBSCRIPTION':
-            case 'PROFILE': return 3;
-            case 'COMPLETED': return 'dashboard';
-            default: return 1;
+            case 'agreement':
+              return 1;
+            case 'payment':
+              return 2;
+            case 'profile':
+              return 3;
+            case 'ready':
+              return 'dashboard';
+            default:
+              return 1;
           }
         };
         const step = stageToStep(data.stage);

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  setupFiles: ['<rootDir>/test-env.cjs']
+};

--- a/migrations/20250518_signup_state.ts
+++ b/migrations/20250518_signup_state.ts
@@ -1,0 +1,24 @@
+import { sql } from 'drizzle-orm';
+
+export async function up(db: any): Promise<void> {
+  await db.execute(sql`\
+    CREATE TABLE IF NOT EXISTS signup_state (
+      user_id INTEGER PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+      status TEXT DEFAULT 'started',
+      updated_at TIMESTAMP DEFAULT NOW()
+    );
+  `);
+  await db.execute(sql`\
+    ALTER TABLE users
+      ADD COLUMN IF NOT EXISTS is_paid BOOLEAN DEFAULT false,
+      ADD COLUMN IF NOT EXISTS has_signed_agreement BOOLEAN DEFAULT false;
+  `);
+}
+
+export async function down(db: any): Promise<void> {
+  await db.execute(sql`ALTER TABLE users DROP COLUMN IF EXISTS has_signed_agreement;`);
+  await db.execute(sql`ALTER TABLE users DROP COLUMN IF EXISTS is_paid;`);
+  await db.execute(sql`DROP TABLE IF EXISTS signup_state;`);
+}
+
+export default { up, down };

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
-    "db:push": "drizzle-kit push"
+    "db:push": "drizzle-kit push",
+    "cleanup:signups": "tsx server/scripts/cleanupIncompleteSignups.ts",
+    "test": "jest"
   },
   "dependencies": {
     "@headlessui/react": "^2.2.2",
@@ -129,7 +131,10 @@
     "tailwindcss": "^3.4.17",
     "tsx": "^4.19.4",
     "typescript": "5.6.3",
-    "vite": "^5.4.14"
+    "vite": "^5.4.14",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "@types/jest": "^29.5.12"
   },
   "optionalDependencies": {
     "bufferutil": "^4.0.8"

--- a/server/__tests__/signup.spec.ts
+++ b/server/__tests__/signup.spec.ts
@@ -1,0 +1,62 @@
+import { startSignup } from '../routes/signupStage';
+import { updateSignupState } from '../routes/signupState';
+import { cleanupIncompleteSignups } from '../scripts/cleanupIncompleteSignups';
+
+jest.mock('../db', () => ({
+  getDb: jest.fn(),
+  initializeDatabase: jest.fn(),
+}));
+import { getDb } from '../db';
+
+const mockDb: any = {
+  select: jest.fn(),
+  insert: jest.fn(),
+  delete: jest.fn(),
+  update: jest.fn(),
+  transaction: jest.fn(),
+};
+(getDb as jest.Mock).mockReturnValue(mockDb);
+
+describe('signup flow', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('duplicate email restart logic', async () => {
+    mockDb.select
+      .mockResolvedValueOnce([{ id: 1 }]) // existing user
+      .mockResolvedValueOnce([{ status: 'started' }]); // signup_state
+    mockDb.transaction.mockImplementation(async (cb: any) => {
+      await cb({
+        delete: jest.fn(),
+        insert: jest.fn().mockReturnValue({ returning: jest.fn().mockResolvedValueOnce([{ id: 2 }]) })
+      });
+    });
+    const req: any = { body: { email: 'a@a.com', username: 'a', phone: '1', password: 'p' } };
+    const res: any = { status: jest.fn(() => res), json: jest.fn() };
+    await startSignup(req, res);
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(res.json).toHaveBeenCalledWith({ userId: 2, step: 'agreement' });
+  });
+
+  test('status cannot regress', async () => {
+    mockDb.select.mockResolvedValueOnce([{ status: 'payment' }]);
+    const update = jest.fn();
+    mockDb.update.mockReturnValue({ set: () => ({ where: update }) });
+    const req: any = { user: { id: 1 }, body: { status: 'started' } };
+    const res: any = { status: jest.fn(() => res), json: jest.fn() };
+    await updateSignupState(req, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  test('cleanup removes stale users', async () => {
+    mockDb.select.mockResolvedValueOnce([{ id: 1 }]);
+    const del = jest.fn();
+    mockDb.transaction.mockImplementation(async (cb: any) => {
+      await cb({ delete: del });
+    });
+    await cleanupIncompleteSignups();
+    expect(del).toHaveBeenCalled();
+  });
+});

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -26,6 +26,7 @@ import { saveAgreementPDF, regenerateAgreementsPDF, createAgreementPDF, generate
 import { serveAgreementPDF, handleAgreementUpload } from './handlers/agreement-handlers';
 import { handleGeneratePDF, handleSignupAgreementUpload, serveAgreementHTML } from './handlers/signup-wizard-handlers';
 import signupStageRouter from './routes/signupStage';
+import signupStateRouter from './routes/signupState';
 import { hashPassword } from './utils/passwordUtils';
 import jwt from 'jsonwebtoken';
 // Sample pitches import removed
@@ -214,6 +215,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   
   // Register signup stage routes once before auth setup
   app.use('/api/signup-stage', signupStageRouter);
+  app.use('/api/signup/state', signupStateRouter);
   
   // Serve the agreement HTML template
   app.get('/api/onboarding/agreement.html', serveAgreementHTML);
@@ -226,6 +228,31 @@ export async function registerRoutes(app: Express): Promise<Server> {
   
   // Set up regular user authentication
   setupAuth(app);
+
+  // Endpoint to report the current signup stage for the authenticated user
+  app.get('/api/auth/progress', (req: Request, res: Response) => {
+    if (!req.isAuthenticated()) {
+      return res.status(401).json({ message: 'Unauthorized' });
+    }
+    const stage = (req.user as any).signup_stage || 'agreement';
+    res.json({ stage });
+  });
+
+  // Endpoint to update the signup stage for the authenticated user
+  app.patch('/api/auth/stage', async (req: Request, res: Response) => {
+    if (!req.isAuthenticated()) {
+      return res.status(401).json({ message: 'Unauthorized' });
+    }
+    const { stage } = req.body as { stage?: string };
+    if (!stage) {
+      return res.status(400).json({ message: 'Stage required' });
+    }
+    await getDb()
+      .update(users)
+      .set({ signup_stage: stage })
+      .where(eq(users.id, req.user.id));
+    res.json({ success: true });
+  });
 
   // Signup stage router is already registered above; duplicate registration removed
   // to avoid redundant handlers after auth setup.

--- a/server/routes/signupStage.ts
+++ b/server/routes/signupStage.ts
@@ -1,8 +1,8 @@
 import 'dotenv/config';
 import { Request, Response, Router } from 'express';
 import { getDb } from '../db';
-import { users } from '@shared/schema';
-import { eq } from 'drizzle-orm';
+import { users, signupState } from '@shared/schema';
+import { eq, sql, and } from 'drizzle-orm';
 import Stripe from 'stripe';
 import path from 'path';
 import fs from 'fs';
@@ -58,6 +58,54 @@ const router = Router();
 
 // Allowed signup stages in order
 const VALID_STAGES = ['agreement', 'payment', 'profile', 'ready', 'legacy'];
+
+export async function startSignup(req: Request, res: Response) {
+  const { email, username, phone, password } = req.body as { email: string; username: string; phone: string; password: string };
+  if (!email || !username || !phone || !password) {
+    return res.status(400).json({ message: 'Missing required fields' });
+  }
+
+  const db = getDb();
+
+  // Check for existing user by email/username/phone
+  const existing = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(sql`LOWER(${users.email}) = LOWER(${email}) OR LOWER(${users.username}) = LOWER(${username}) OR ${users.phone_number} = ${phone}`)
+    .limit(1);
+
+  if (existing.length) {
+    const userId = existing[0].id as number;
+    const [state] = await db.select().from(signupState).where(eq(signupState.userId, userId));
+    if (state && state.status !== 'completed') {
+      await db.transaction(async (tx) => {
+        await tx.delete(signupState).where(eq(signupState.userId, userId));
+        await tx.delete(users).where(eq(users.id, userId));
+      });
+    } else {
+      return res.status(400).json({ message: 'User already exists' });
+    }
+  }
+
+  const hashed = await hashPassword(password);
+
+  let newId: number | undefined;
+  await db.transaction(async (tx) => {
+    const inserted = await tx.insert(users).values({
+      email,
+      username,
+      phone_number: phone,
+      password: hashed,
+      signup_stage: 'agreement',
+    }).returning({ id: users.id });
+    newId = inserted[0].id as number;
+    await tx.insert(signupState).values({ userId: newId! });
+  });
+
+  return res.status(201).json({ userId: newId, step: 'agreement' });
+}
+
+router.post('/start', startSignup);
 
 // Get the current signup stage for a user
 router.get('/:email', async (req: Request, res: Response) => {
@@ -619,8 +667,8 @@ async function generateAgreementPDF(fullName: string, signature: string, signedA
   });
 }
 
-// Update signup stage
-router.patch('/api/auth/stage', async (req: Request, res: Response) => {
+// Update signup stage (not used by wizard, kept for backward compatibility)
+router.patch('/stage', async (req: Request, res: Response) => {
   const userId = req.user?.id;
   const { stage } = req.body;
   if (!userId) return res.status(401).json({ message: 'Unauthorized' });

--- a/server/routes/signupState.ts
+++ b/server/routes/signupState.ts
@@ -1,0 +1,34 @@
+import { Router, Request, Response } from 'express';
+import { getDb } from '../db';
+import { signupState } from '@shared/schema';
+import { eq } from 'drizzle-orm';
+
+const router = Router();
+const ORDER = ['started', 'payment', 'profile', 'completed'];
+
+export async function updateSignupState(req: Request, res: Response) {
+  const userId = req.user?.id as number | undefined;
+  const { status } = req.body as { status?: 'payment' | 'profile' | 'completed' };
+  if (!userId) return res.status(401).json({ message: 'Unauthorized' });
+  if (!status || !ORDER.includes(status)) return res.status(400).json({ message: 'Invalid status' });
+
+  const db = getDb();
+  const [current] = await db.select().from(signupState).where(eq(signupState.userId, userId));
+  if (!current) return res.status(400).json({ message: 'Signup not started' });
+
+  const currentIndex = ORDER.indexOf(current.status as string);
+  const newIndex = ORDER.indexOf(status);
+  if (newIndex < currentIndex) {
+    return res.status(400).json({ message: 'Cannot go backwards' });
+  }
+
+  await db.update(signupState)
+    .set({ status, updatedAt: new Date() })
+    .where(eq(signupState.userId, userId));
+
+  return res.json({ status });
+}
+
+router.patch('/', updateSignupState);
+
+export default router;

--- a/server/scripts/cleanupIncompleteSignups.ts
+++ b/server/scripts/cleanupIncompleteSignups.ts
@@ -1,0 +1,31 @@
+import { initializeDatabase, getDb } from '../db';
+import { signupState, users } from '@shared/schema';
+import { lt, ne, eq, and } from 'drizzle-orm';
+
+export async function cleanupIncompleteSignups(): Promise<void> {
+  initializeDatabase();
+  const db = getDb();
+  const cutoff = new Date(Date.now() - 30 * 60 * 1000);
+  const stale = await db
+    .select({ id: users.id })
+    .from(users)
+    .leftJoin(signupState, eq(users.id, signupState.userId))
+    .where(and(ne(signupState.status, 'completed'), lt(users.createdAt, cutoff)));
+
+  for (const row of stale) {
+    await db.transaction(async (tx) => {
+      await tx.delete(signupState).where(eq(signupState.userId, row.id));
+      await tx.delete(users).where(eq(users.id, row.id));
+    });
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  cleanupIncompleteSignups().then(() => {
+    console.log('cleanup finished');
+    process.exit(0);
+  }).catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary
- support stateful signup table and flags
- add API endpoints to start signup and patch signup state
- include cleanup script for stale incomplete signups
- wire up Jest with basic signup tests

## Testing
- `npm run --silent check` *(fails: Cannot find type definition file for 'node')*
- `pnpm test` *(fails: jest not found)*