### PR TITLE
Remove duplicate PDF and agreement routes

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -256,12 +256,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
   // Signup stage router is already registered above; duplicate registration removed
   // to avoid redundant handlers after auth setup.
-  
-  // Setup PDF generation endpoints for the agreement
-  app.post('/api/generate-pdf', handleGeneratePDF);
-  app.get('/api/onboarding/agreement.html', serveAgreementHTML);
 
-  
   // Set up admin authentication
   setupAdminAuth(app);
   


### PR DESCRIPTION
## Summary
- keep single registration of `/api/generate-pdf` and `/api/onboarding/agreement.html`
- delete repeated definitions after auth setup

## Testing
- `npm test` *(fails: jest not found)*