### PR TITLE
Add consolidated signup router

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -27,6 +27,7 @@ import { serveAgreementPDF, handleAgreementUpload } from './handlers/agreement-h
 import { handleGeneratePDF, handleSignupAgreementUpload, serveAgreementHTML } from './handlers/signup-wizard-handlers';
 import signupStageRouter from './routes/signupStage';
 import signupStateRouter from './routes/signupState';
+import signupRouter from './routes/signup';
 import { hashPassword } from './utils/passwordUtils';
 import jwt from 'jsonwebtoken';
 // Sample pitches import removed
@@ -216,6 +217,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   // Register signup stage routes once before auth setup
   app.use('/api/signup-stage', signupStageRouter);
   app.use('/api/signup/state', signupStateRouter);
+  app.use('/api/signup', signupRouter);
   
   // Serve the agreement HTML template
   app.get('/api/onboarding/agreement.html', serveAgreementHTML);

--- a/server/routes/signup.ts
+++ b/server/routes/signup.ts
@@ -1,0 +1,10 @@
+import { Router } from 'express';
+import { startSignup } from './signupStage';
+import { updateSignupState } from './signupState';
+
+const router = Router();
+
+router.post('/start', startSignup);
+router.patch('/state', updateSignupState);
+
+export default router;


### PR DESCRIPTION
## Summary
- expose signup start and state routes through new router
- register router at `/api/signup`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run check` *(fails: missing type definitions)*