### PR TITLE
Fix signup wizard login issue

### DIFF
--- a/server/auth.ts
+++ b/server/auth.ts
@@ -2,8 +2,7 @@ import passport from "passport";
 import { Strategy as LocalStrategy } from "passport-local";
 import { Express } from "express";
 import session from "express-session";
-import { scrypt, randomBytes, timingSafeEqual } from "crypto";
-import { promisify } from "util";
+import { hashPassword, comparePasswords } from "./utils/passwordUtils";
 import { storage } from "./storage";
 import { User as SelectUser } from "@shared/schema";
 import { z } from "zod";
@@ -31,20 +30,6 @@ declare global {
 }
 
 const PostgresSessionStore = connectPg(session);
-const scryptAsync = promisify(scrypt);
-
-async function hashPassword(password: string) {
-  const salt = randomBytes(16).toString("hex");
-  const buf = (await scryptAsync(password, salt, 64)) as Buffer;
-  return `${buf.toString("hex")}.${salt}`;
-}
-
-async function comparePasswords(supplied: string, stored: string) {
-  const [hashed, salt] = stored.split(".");
-  const hashedBuf = Buffer.from(hashed, "hex");
-  const suppliedBuf = (await scryptAsync(supplied, salt, 64)) as Buffer;
-  return timingSafeEqual(hashedBuf, suppliedBuf);
-}
 
 export function setupAuth(app: Express) {
   const sessionSettings: session.SessionOptions = {

--- a/server/routes/signupStage.ts
+++ b/server/routes/signupStage.ts
@@ -614,8 +614,15 @@ router.post('/:email/complete', async (req: Request, res: Response) => {
       { expiresIn: '7d' }
     );
     
-    return res.status(200).json({ 
-      success: true, 
+    // Also log the user in via session
+    await new Promise<void>((resolve, reject) => {
+      req.login(user, (err) => {
+        if (err) reject(err); else resolve();
+      });
+    });
+
+    return res.status(200).json({
+      success: true,
       token,
       user: {
         id: user.id,

--- a/server/utils/passwordUtils.ts
+++ b/server/utils/passwordUtils.ts
@@ -1,10 +1,28 @@
-import bcrypt from 'bcrypt';
+import { scrypt, randomBytes, timingSafeEqual } from 'crypto';
+import { promisify } from 'util';
 
+const scryptAsync = promisify(scrypt);
+
+/**
+ * Hash a password using scrypt with a random salt.
+ * Returns the hashed value in the format `${hash}.${salt}`.
+ */
 export async function hashPassword(password: string): Promise<string> {
-  const saltRounds = 10;
-  return bcrypt.hash(password, saltRounds);
+  const salt = randomBytes(16).toString('hex');
+  const buf = (await scryptAsync(password, salt, 64)) as Buffer;
+  return `${buf.toString('hex')}.${salt}`;
 }
 
+/**
+ * Compare a plain password against a stored scrypt hash.
+ */
 export async function comparePasswords(plainPassword: string, hashedPassword: string): Promise<boolean> {
-  return bcrypt.compare(plainPassword, hashedPassword);
-} 
+  const parts = hashedPassword.split('.');
+  if (parts.length !== 2) return false;
+  const [hashed, salt] = parts;
+  if (!hashed || !salt) return false;
+  const hashedBuf = Buffer.from(hashed, 'hex');
+  const suppliedBuf = (await scryptAsync(plainPassword, salt, 64)) as Buffer;
+  if (hashedBuf.length !== suppliedBuf.length) return false;
+  return timingSafeEqual(hashedBuf, suppliedBuf);
+}


### PR DESCRIPTION
## Summary
- unify password hashing with scrypt
- log user in on signup completion
- harden password comparison
- use shared hash utilities in auth

## Testing
- `npx jest` *(fails: EHOSTUNREACH for registry.npmjs.org)*
- `npm run check` *(fails: missing type definitions)*