### PR TITLE
Fix signup wizard login issue

### DIFF
--- a/client/src/hooks/use-auth.tsx
+++ b/client/src/hooks/use-auth.tsx
@@ -48,9 +48,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         const errorData = await res.json();
         throw new Error(errorData.message || "Login failed");
       }
-      return await res.json();
+      return (await res.json()) as { user: SelectUser } | SelectUser;
     },
-    onSuccess: (user: SelectUser) => {
+    onSuccess: (data: { user: SelectUser } | SelectUser) => {
+      const user = "user" in data ? data.user : data;
       queryClient.setQueryData(["/api/user"], user);
       toast({
         title: "Login successful",
@@ -79,9 +80,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         const errorData = await res.json();
         throw new Error(errorData.message || "Registration failed");
       }
-      return await res.json();
+      return (await res.json()) as { user: SelectUser } | SelectUser;
     },
-    onSuccess: (user: SelectUser) => {
+    onSuccess: (data: { user: SelectUser } | SelectUser) => {
+      const user = "user" in data ? data.user : data;
       queryClient.setQueryData(["/api/user"], user);
     },
     onError: (error: Error) => {

--- a/client/src/pages/auth-page.tsx
+++ b/client/src/pages/auth-page.tsx
@@ -89,6 +89,7 @@ export default function AuthPage() {
   const [location, navigate] = useLocation();
   const [search, setSearch] = useState(window.location.search);
   const [highestStep, setHighestStep] = useState(1);
+  const { toast } = useToast();
 
   // Track highest step reached
   useEffect(() => {
@@ -138,6 +139,7 @@ export default function AuthPage() {
         await post('/api/login', { username: signupData.username, password: signupData.password });
       } catch (err) {
         console.error('Auto-login failed:', err);
+        toast({ title: 'Auto-login failed', description: 'Please log in manually', variant: 'destructive' });
       }
     }
     localStorage.setItem('token', token);

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -59,8 +59,9 @@ export function setupAuth(app: Express) {
     cookie: {
       maxAge: 30 * 24 * 60 * 60 * 1000, // 30 days
       secure: process.env.NODE_ENV === "production",
-      httpOnly: true
-    }
+      httpOnly: true,
+      sameSite: "lax",
+    },
   };
 
   app.set("trust proxy", 1);
@@ -121,9 +122,8 @@ export function setupAuth(app: Express) {
       // Log the user in
       req.login(user, (err) => {
         if (err) return next(err);
-        // Return user without password
         const { password, ...userWithoutPassword } = user;
-        res.status(201).json(userWithoutPassword);
+        res.status(201).json({ success: true, user: userWithoutPassword });
       });
     } catch (err) {
       next(err);
@@ -139,9 +139,8 @@ export function setupAuth(app: Express) {
       
       req.login(user, (err) => {
         if (err) return next(err);
-        // Return user without password
         const { password, ...userWithoutPassword } = user;
-        res.status(200).json(userWithoutPassword);
+        res.status(200).json({ success: true, user: userWithoutPassword });
       });
     })(req, res, next);
   });

--- a/server/utils/passwordUtils.ts
+++ b/server/utils/passwordUtils.ts
@@ -1,10 +1,33 @@
-import bcrypt from 'bcrypt';
+import { scrypt, randomBytes, timingSafeEqual } from 'crypto';
+import { promisify } from 'util';
 
+const scryptAsync = promisify(scrypt);
+
+/**
+ * Hash a password using scrypt with a random salt.
+ * Returns the hashed value in the format `${hash}.${salt}`.
+ */
 export async function hashPassword(password: string): Promise<string> {
-  const saltRounds = 10;
-  return bcrypt.hash(password, saltRounds);
+  const salt = randomBytes(16).toString('hex');
+  const buf = (await scryptAsync(password, salt, 64)) as Buffer;
+  return `${buf.toString('hex')}.${salt}`;
 }
 
-export async function comparePasswords(plainPassword: string, hashedPassword: string): Promise<boolean> {
-  return bcrypt.compare(plainPassword, hashedPassword);
-} 
+/**
+ * Compare a plain password against a stored scrypt hash.
+ */
+export async function comparePasswords(
+  plainPassword: string,
+  hashedPassword: string,
+): Promise<boolean> {
+  const [hash, salt] = hashedPassword.split('.');
+  if (!hash || !salt) {
+    return false;
+  }
+  const hashedBuf = Buffer.from(hash, 'hex');
+  const suppliedBuf = (await scryptAsync(plainPassword, salt, 64)) as Buffer;
+  if (hashedBuf.length !== suppliedBuf.length) {
+    return false;
+  }
+  return timingSafeEqual(hashedBuf, suppliedBuf);
+}


### PR DESCRIPTION
## Summary
- unify password hashing with scrypt
- return a consistent payload from login/register endpoints and handle it in the client
- show toast if auto login fails

## Testing
- `npx jest` *(fails: command not found)*
- `npm run check` *(fails: missing type definitions)*