### PR TITLE
Add JWT authentication middleware

### DIFF
--- a/server/middleware/jwtAuth.ts
+++ b/server/middleware/jwtAuth.ts
@@ -1,0 +1,36 @@
+import { Request, Response, NextFunction } from 'express';
+import jwt from 'jsonwebtoken';
+import { getDb } from '../db';
+import { users } from '@shared/schema';
+import { eq } from 'drizzle-orm';
+
+/**
+ * Middleware to authenticate requests using a JWT token.
+ * If a valid token is present in the Authorization header,
+ * the corresponding user is loaded and attached to `req.user`.
+ * This allows existing `req.isAuthenticated()` checks to work
+ * even without a session.
+ */
+export async function jwtAuth(req: Request, _res: Response, next: NextFunction) {
+  if (req.user) return next();
+
+  const authHeader = req.headers['authorization'];
+  const token = authHeader?.startsWith('Bearer ')
+    ? authHeader.slice(7)
+    : undefined;
+
+  if (!token) return next();
+
+  try {
+    const payload = jwt.verify(token, process.env.JWT_SECRET || 'quotebid_secret') as { id: number };
+    const [user] = await getDb().select().from(users).where(eq(users.id, payload.id));
+    if (user) {
+      // Assign user so `req.isAuthenticated()` returns true
+      (req as any).user = user;
+    }
+  } catch (err) {
+    // Ignore invalid token
+  }
+
+  next();
+}

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -19,6 +19,7 @@ import { requireAdmin } from "./middleware/admin";
 import { registerAdmin, deleteAdminUser, createDefaultAdmin } from "./admin-auth";
 import { setupAdminAuth, requireAdminAuth } from "./admin-auth-middleware";
 import { enforceOnboarding } from "./middleware/enforceOnboarding";
+import { jwtAuth } from "./middleware/jwtAuth";
 import upload from './middleware/upload';
 import path from 'path';
 import fs from 'fs';
@@ -254,6 +255,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
   
   // Set up regular user authentication
   setupAuth(app);
+  // Allow JWT-based auth for API requests
+  app.use(jwtAuth);
 
   // Endpoint to report the current signup stage for the authenticated user
   app.get('/api/auth/progress', (req: Request, res: Response) => {


### PR DESCRIPTION
## Summary
- add new `jwtAuth` middleware to authenticate requests with JWT token
- hook middleware into API routes so JWT-based logins work

## Testing
- `npm test` *(fails: jest not found)*