### PR TITLE
Add JWT to all API requests

### DIFF
--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -1,13 +1,21 @@
 export async function get(url: string) {
-  const res = await fetch(url, { credentials: 'include' });
+  const token = localStorage.getItem('token');
+  const res = await fetch(url, {
+    credentials: 'include',
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
   if (!res.ok) throw new Error(await res.text());
   return res.json();
 }
 
 export async function patch(url: string, body: any) {
+  const token = localStorage.getItem('token');
   const res = await fetch(url, {
     method: 'PATCH',
-    headers: { 'Content-Type': 'application/json' },
+    headers: {
+      'Content-Type': 'application/json',
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
     credentials: 'include',
     body: JSON.stringify(body),
   });
@@ -16,9 +24,13 @@ export async function patch(url: string, body: any) {
 }
 
 export async function post(url: string, body: any) {
+  const token = localStorage.getItem('token');
   const res = await fetch(url, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: {
+      'Content-Type': 'application/json',
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
     credentials: 'include',
     body: JSON.stringify(body),
   });

--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -51,8 +51,10 @@ export const getQueryFn: <T>(options: {
 }) => QueryFunction<T> =
   ({ on401: unauthorizedBehavior }) =>
   async ({ queryKey }) => {
+    const token = localStorage.getItem("token");
     const res = await fetch(queryKey[0] as string, {
       credentials: "include",
+      headers: token ? { Authorization: `Bearer ${token}` } : {},
     });
 
     if (unauthorizedBehavior === "returnNull" && res.status === 401) {

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -10,6 +10,7 @@ import path from "path";
 import fs from "fs";
 import connectPg from "connect-pg-simple";
 import { getPool } from "./db";
+import jwt from 'jsonwebtoken';
 
 // Path to uploads directory for avatars
 const uploadsPath = path.join(process.cwd(), "uploads");
@@ -108,7 +109,15 @@ export function setupAuth(app: Express) {
       req.login(user, (err) => {
         if (err) return next(err);
         const { password, ...userWithoutPassword } = user;
-        res.status(201).json({ success: true, user: userWithoutPassword });
+        const token = jwt.sign(
+          {
+            id: user.id,
+            email: user.email,
+          },
+          process.env.JWT_SECRET || 'quotebid_secret',
+          { expiresIn: '7d' }
+        );
+        res.status(201).json({ success: true, user: userWithoutPassword, token });
       });
     } catch (err) {
       next(err);
@@ -125,7 +134,15 @@ export function setupAuth(app: Express) {
       req.login(user, (err) => {
         if (err) return next(err);
         const { password, ...userWithoutPassword } = user;
-        res.status(200).json({ success: true, user: userWithoutPassword });
+        const token = jwt.sign(
+          {
+            id: user.id,
+            email: user.email,
+          },
+          process.env.JWT_SECRET || 'quotebid_secret',
+          { expiresIn: '7d' }
+        );
+        res.status(200).json({ success: true, user: userWithoutPassword, token });
       });
     })(req, res, next);
   });

--- a/server/middleware/jwtAuth.ts
+++ b/server/middleware/jwtAuth.ts
@@ -1,0 +1,36 @@
+import { Request, Response, NextFunction } from 'express';
+import jwt from 'jsonwebtoken';
+import { getDb } from '../db';
+import { users } from '@shared/schema';
+import { eq } from 'drizzle-orm';
+
+/**
+ * Middleware to authenticate requests using a JWT token.
+ * If a valid token is present in the Authorization header,
+ * the corresponding user is loaded and attached to `req.user`.
+ * This allows existing `req.isAuthenticated()` checks to work
+ * even without a session.
+ */
+export async function jwtAuth(req: Request, _res: Response, next: NextFunction) {
+  if (req.user) return next();
+
+  const authHeader = req.headers['authorization'];
+  const token = authHeader?.startsWith('Bearer ')
+    ? authHeader.slice(7)
+    : undefined;
+
+  if (!token) return next();
+
+  try {
+    const payload = jwt.verify(token, process.env.JWT_SECRET || 'quotebid_secret') as { id: number };
+    const [user] = await getDb().select().from(users).where(eq(users.id, payload.id));
+    if (user) {
+      // Assign user so `req.isAuthenticated()` returns true
+      (req as any).user = user;
+    }
+  } catch (err) {
+    // Ignore invalid token
+  }
+
+  next();
+}

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -19,6 +19,7 @@ import { requireAdmin } from "./middleware/admin";
 import { registerAdmin, deleteAdminUser, createDefaultAdmin } from "./admin-auth";
 import { setupAdminAuth, requireAdminAuth } from "./admin-auth-middleware";
 import { enforceOnboarding } from "./middleware/enforceOnboarding";
+import { jwtAuth } from "./middleware/jwtAuth";
 import upload from './middleware/upload';
 import path from 'path';
 import fs from 'fs';
@@ -254,6 +255,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
   
   // Set up regular user authentication
   setupAuth(app);
+  // Allow JWT-based auth for API requests
+  app.use(jwtAuth);
 
   // Endpoint to report the current signup stage for the authenticated user
   app.get('/api/auth/progress', (req: Request, res: Response) => {


### PR DESCRIPTION
## Summary
- ensure API requests include stored JWT
- return JWT token from `/api/login` and `/api/register`
- read token in query functions

## Testing
- `npm test` *(fails: jest not found)*