### PR TITLE
Add JWT authentication middleware

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,5 +1,6 @@
 import { Switch, Route, Redirect, useLocation, Link } from "wouter";
 import { QueryClientProvider, useQuery } from "@tanstack/react-query";
+import { apiFetch } from "@/lib/apiFetch";
 import { queryClient } from "./lib/queryClient";
 import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -332,7 +333,7 @@ function Router() {
                                 const { data: opportunities, isLoading } = useQuery({
                                   queryKey: ['/api/opportunities'],
                                   queryFn: async () => {
-                                    const res = await fetch('/api/opportunities');
+                                    const res = await apiFetch('/api/opportunities');
                                     if (!res.ok) throw new Error('Failed to fetch opportunities');
                                     return res.json();
                                   },
@@ -380,7 +381,7 @@ function Router() {
                                 const { data: pitches, isLoading } = useQuery({
                                   queryKey: ['/api/admin/pitches'],
                                   queryFn: async () => {
-                                    const res = await fetch('/api/admin/pitches');
+                                    const res = await apiFetch('/api/admin/pitches');
                                     if (!res.ok) throw new Error('Failed to fetch pitches');
                                     return res.json();
                                   },
@@ -428,7 +429,7 @@ function Router() {
                                 const { data: activity, isLoading } = useQuery({
                                   queryKey: ['/api/admin/user-activity'],
                                   queryFn: async () => {
-                                    const res = await fetch('/api/admin/user-activity');
+                                    const res = await apiFetch('/api/admin/user-activity');
                                     if (!res.ok) throw new Error('Failed to fetch user activity');
                                     return res.json();
                                   },
@@ -463,7 +464,7 @@ function Router() {
                                     const { data } = useQuery({
                                       queryKey: ['/api/admin/user-activity'],
                                       queryFn: async () => {
-                                        const res = await fetch('/api/admin/user-activity');
+                                        const res = await apiFetch('/api/admin/user-activity');
                                         if (!res.ok) throw new Error('Failed to fetch user activity');
                                         return res.json();
                                       },
@@ -484,7 +485,7 @@ function Router() {
                                     const { data } = useQuery({
                                       queryKey: ['/api/admin/user-activity'],
                                       queryFn: async () => {
-                                        const res = await fetch('/api/admin/user-activity');
+                                        const res = await apiFetch('/api/admin/user-activity');
                                         if (!res.ok) throw new Error('Failed to fetch user activity');
                                         return res.json();
                                       },
@@ -515,7 +516,7 @@ function Router() {
                                 const { data: users, isLoading } = useQuery({
                                   queryKey: ['/api/admin/users'],
                                   queryFn: async () => {
-                                    const res = await fetch('/api/admin/users');
+                                    const res = await apiFetch('/api/admin/users');
                                     if (!res.ok) throw new Error('Failed to fetch users');
                                     return res.json();
                                   },

--- a/client/src/components/admin/admin-pitches-list.tsx
+++ b/client/src/components/admin/admin-pitches-list.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { apiFetch } from '@/lib/apiFetch';
 import { useQuery } from '@tanstack/react-query';
 import { Loader2, FileText, Mic, Check, X, ChevronDown, List, LayoutGrid, Send } from 'lucide-react';
 import { format } from 'date-fns';
@@ -98,7 +99,7 @@ export default function AdminPitchesList({ filter = 'all' }: AdminPitchesListPro
     queryKey: ['/api/admin/pitches'],
     queryFn: async () => {
       console.log('Fetching admin pitches...');
-      const res = await fetch('/api/admin/pitches', {
+      const res = await apiFetch('/api/admin/pitches', {
         method: 'GET',
         credentials: 'include',
         headers: {

--- a/client/src/components/signup/AgreementStep.tsx
+++ b/client/src/components/signup/AgreementStep.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
+import { apiFetch } from '@/lib/apiFetch';
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Loader2 } from 'lucide-react';
@@ -102,7 +103,7 @@ export function AgreementStep({ onComplete }: AgreementStepProps) {
       // Get current timestamp
       const signedAt = new Date().toISOString();
       // Get IP address
-      const ipAddress = await fetch('https://api.ipify.org?format=json').then(res => res.json()).then(data => data.ip);
+      const ipAddress = await apiFetch('https://api.ipify.org?format=json').then(res => res.json()).then(data => data.ip);
 
       // Store agreement data in localStorage
       localStorage.setItem('signup_agreement', JSON.stringify({ 

--- a/client/src/components/signup/ProfileStep.tsx
+++ b/client/src/components/signup/ProfileStep.tsx
@@ -7,6 +7,7 @@ import { useToast } from "@/hooks/use-toast";
 import { getSignupEmail, getSignupData, updateSignupProfile, clearSignupData } from '@/lib/signup-wizard';
 import { useSignupWizard } from '@/contexts/SignupWizardContext';
 import { post } from '@/lib/api';
+import { apiFetch } from '@/lib/apiFetch';
 import { INDUSTRY_OPTIONS } from "@/lib/constants";
 import { useSignupGuard } from '@/hooks/useSignupGuard';
 
@@ -81,7 +82,7 @@ export function ProfileStep({ onComplete }: ProfileStepProps) {
       if (avatar) {
         const formData = new FormData();
         formData.append('avatar', avatar);
-        await fetch(`/api/signup-stage/${encodeURIComponent(email)}/avatar`, {
+        await apiFetch(`/api/signup-stage/${encodeURIComponent(email)}/avatar`, {
           method: 'POST',
           body: formData,
         });

--- a/client/src/hooks/use-admin-auth.tsx
+++ b/client/src/hooks/use-admin-auth.tsx
@@ -6,6 +6,7 @@ import {
 } from "@tanstack/react-query";
 import { AdminUser } from "@shared/schema";
 import { apiRequest, queryClient } from "@/lib/queryClient";
+import { apiFetch } from "@/lib/apiFetch";
 import { useToast } from "@/hooks/use-toast";
 
 type AdminLoginData = {
@@ -41,7 +42,7 @@ export function AdminAuthProvider({ children }: { children: ReactNode }) {
     queryFn: async () => {
       try {
         console.log("Checking admin authentication status...");
-        const res = await fetch("/api/admin/current", {
+        const res = await apiFetch("/api/admin/current", {
           credentials: "include",
           headers: {
             "Cache-Control": "no-cache",

--- a/client/src/hooks/use-current-user.tsx
+++ b/client/src/hooks/use-current-user.tsx
@@ -1,11 +1,12 @@
 import { useQuery } from '@tanstack/react-query';
 import { User } from '@shared/schema';
+import { apiFetch } from '@/lib/apiFetch';
 
 export function useCurrentUser() {
   const { data, isLoading, error, refetch } = useQuery<User>({
     queryKey: ['/api/user'],
     queryFn: async () => {
-      const response = await fetch('/api/user');
+      const response = await apiFetch('/api/user');
       if (!response.ok) {
         if (response.status === 401) {
           throw new Error('You must be logged in to access this resource');

--- a/client/src/lib/apiFetch.ts
+++ b/client/src/lib/apiFetch.ts
@@ -1,0 +1,10 @@
+/** Fetch wrapper that automatically adds JWT token to every request */
+export async function apiFetch(
+  input: RequestInfo,
+  init: RequestInit = {}
+) {
+  const token = localStorage.getItem('token');
+  const headers = new Headers(init.headers || {});
+  if (token) headers.set('Authorization', `Bearer ${token}`);
+  return fetch(input, { ...init, headers, credentials: 'include' });
+}

--- a/client/src/lib/pdf-utils.ts
+++ b/client/src/lib/pdf-utils.ts
@@ -1,5 +1,6 @@
 import { getSignupEmail } from './signup-wizard';
 import { apiRequest } from './queryClient';
+import { apiFetch } from '@/lib/apiFetch';
 
 interface SignatureInfo {
   signature: string;
@@ -21,7 +22,7 @@ export async function generateAgreementPDF(
 ): Promise<Blob> {
   try {
     // Use an external PDF generation service
-    const response = await fetch('/api/generate-pdf', {
+    const response = await apiFetch('/api/generate-pdf', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -66,7 +67,7 @@ export async function uploadAgreementPDF(userId: number, pdfData: Blob): Promise
       formData.append('userId', userId.toString());
     }
 
-    const response = await fetch('/api/upload-agreement', {
+    const response = await apiFetch('/api/upload-agreement', {
       method: 'POST',
       body: formData,
     });
@@ -89,7 +90,7 @@ export async function uploadAgreementPDF(userId: number, pdfData: Blob): Promise
  */
 export async function downloadAgreementPDF(userId: number): Promise<Blob> {
   try {
-    const response = await fetch(`/api/download-agreement/${userId}`);
+    const response = await apiFetch(`/api/download-agreement/${userId}`);
     
     if (!response.ok) {
       throw new Error('Failed to download agreement');

--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -1,4 +1,5 @@
 import { QueryClient, QueryFunction } from "@tanstack/react-query";
+import { apiFetch } from "@/lib/apiFetch";
 
 async function throwIfResNotOk(res: Response) {
   if (!res.ok) {
@@ -19,7 +20,7 @@ export async function apiRequest(
 ): Promise<Response> {
   // Allow custom config to override defaults (for FormData, etc.)
   if (options?.customConfig) {
-    const res = await fetch(url, {
+    const res = await apiFetch(url, {
       method,
       credentials: "include",
       ...options.customConfig
@@ -30,12 +31,10 @@ export async function apiRequest(
   }
   
   // Standard JSON request
-  const token = localStorage.getItem("token");
-  const res = await fetch(url, {
+  const res = await apiFetch(url, {
     method,
     headers: {
       ...(data ? { "Content-Type": "application/json" } : {}),
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
     },
     body: data ? JSON.stringify(data) : undefined,
     credentials: "include",
@@ -51,7 +50,7 @@ export const getQueryFn: <T>(options: {
 }) => QueryFunction<T> =
   ({ on401: unauthorizedBehavior }) =>
   async ({ queryKey }) => {
-    const res = await fetch(queryKey[0] as string, {
+    const res = await apiFetch(queryKey[0] as string, {
       credentials: "include",
     });
 

--- a/client/src/lib/websocket.ts
+++ b/client/src/lib/websocket.ts
@@ -1,0 +1,7 @@
+const WS_PORT = import.meta.env.VITE_WS_PORT || 5050; // fallback for dev
+
+export function setupWebSocket(token: string): WebSocket {
+  return new WebSocket(
+    `ws://${window.location.hostname}:${WS_PORT}?token=${token}`
+  );
+}

--- a/client/src/pages/account-fixed.tsx
+++ b/client/src/pages/account-fixed.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { apiFetch } from '@/lib/apiFetch';
 import { useAuth } from '@/hooks/use-auth';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { 
@@ -76,7 +77,7 @@ export default function AccountPage() {
     setIsSaving(true);
     try {
       // Call the actual API endpoint
-      const response = await fetch(`/api/users/${user.id}/industry`, {
+      const response = await apiFetch(`/api/users/${user.id}/industry`, {
         method: 'PATCH',
         headers: {
           'Content-Type': 'application/json',

--- a/client/src/pages/account.tsx
+++ b/client/src/pages/account.tsx
@@ -8,6 +8,7 @@ import { z } from 'zod';
 import { useToast } from '@/hooks/use-toast';
 import { toast } from '@/hooks/use-toast';
 import { apiRequest } from '@/lib/queryClient';
+import { apiFetch } from '@/lib/apiFetch';
 import { INDUSTRY_OPTIONS } from '@/lib/constants';
 import { format } from 'date-fns';
 import { Link } from 'wouter';
@@ -279,7 +280,7 @@ export default function AccountPage() {
           formData.append('avatar', avatarFile);
           
           console.log('Sending avatar upload request to:', `/api/users/${user.id}/avatar`);
-          const response = await fetch(`/api/users/${user.id}/avatar`, {
+          const response = await apiFetch(`/api/users/${user.id}/avatar`, {
             method: 'POST',
             body: formData,
           });

--- a/client/src/pages/admin/analytics.tsx
+++ b/client/src/pages/admin/analytics.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
+import { apiFetch } from "@/lib/apiFetch";
 import {
   Card,
   CardContent,
@@ -64,7 +65,7 @@ export default function AdminAnalytics() {
   const { data: userActivity, isLoading: userActivityLoading } = useQuery({
     queryKey: ['/api/admin/user-activity'],
     queryFn: async () => {
-      const res = await fetch('/api/admin/user-activity');
+      const res = await apiFetch('/api/admin/user-activity');
       if (!res.ok) throw new Error('Failed to fetch user activity');
       return res.json();
     },
@@ -73,7 +74,7 @@ export default function AdminAnalytics() {
   const { data: users, isLoading: usersLoading } = useQuery({
     queryKey: ['/api/admin/users'],
     queryFn: async () => {
-      const res = await fetch('/api/admin/users');
+      const res = await apiFetch('/api/admin/users');
       if (!res.ok) throw new Error('Failed to fetch users');
       return res.json();
     },
@@ -82,7 +83,7 @@ export default function AdminAnalytics() {
   const { data: opportunities, isLoading: opportunitiesLoading } = useQuery({
     queryKey: ['/api/opportunities'],
     queryFn: async () => {
-      const res = await fetch('/api/opportunities');
+      const res = await apiFetch('/api/opportunities');
       if (!res.ok) throw new Error('Failed to fetch opportunities');
       return res.json();
     },
@@ -91,7 +92,7 @@ export default function AdminAnalytics() {
   const { data: pitches, isLoading: pitchesLoading } = useQuery({
     queryKey: ['/api/admin/pitches'],
     queryFn: async () => {
-      const res = await fetch('/api/admin/pitches');
+      const res = await apiFetch('/api/admin/pitches');
       if (!res.ok) throw new Error('Failed to fetch pitches');
       return res.json();
     },

--- a/client/src/pages/admin/billing-manager.tsx
+++ b/client/src/pages/admin/billing-manager.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import { apiRequest, queryClient } from '@/lib/queryClient';
+import { apiFetch } from '@/lib/apiFetch';
 import { Loader2, CreditCard } from 'lucide-react';
 import { 
   Dialog,
@@ -80,7 +81,7 @@ const BillingManager = () => {
         formData.append('articleUrl', data.articleUrl);
         
         // Upload the file first
-        const uploadRes = await fetch(`/api/admin/placements/${data.placementId}/upload`, {
+        const uploadRes = await apiFetch(`/api/admin/placements/${data.placementId}/upload`, {
           method: 'POST',
           body: formData,
         });

--- a/client/src/pages/admin/coverage-manager.tsx
+++ b/client/src/pages/admin/coverage-manager.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import { apiRequest, queryClient } from '@/lib/queryClient';
+import { apiFetch } from '@/lib/apiFetch';
 import { useToast } from '@/hooks/use-toast';
 import { Loader2, RefreshCw, CheckCircle, Link, Share2, FileText, ExternalLink } from 'lucide-react';
 import { 
@@ -102,7 +103,7 @@ const CoverageManager = () => {
         formData.append('articleUrl', data.articleUrl);
         
         // Upload the file
-        const uploadRes = await fetch(`/api/admin/placements/${data.placementId}/upload`, {
+        const uploadRes = await apiFetch(`/api/admin/placements/${data.placementId}/upload`, {
           method: 'POST',
           body: formData,
         });

--- a/client/src/pages/admin/login-test.tsx
+++ b/client/src/pages/admin/login-test.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { apiFetch } from '@/lib/apiFetch';
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -20,7 +21,7 @@ export default function AdminLoginTest() {
     setError(null);
     
     try {
-      const response = await fetch('/api/admin/login', {
+      const response = await apiFetch('/api/admin/login', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/client/src/pages/admin/opportunities-manager.tsx
+++ b/client/src/pages/admin/opportunities-manager.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useToast } from "@/hooks/use-toast";
 import { apiRequest } from "@/lib/queryClient";
+import { apiFetch } from "@/lib/apiFetch";
 import { 
   Card, 
   CardContent, 
@@ -425,7 +426,7 @@ export default function OpportunitiesManager() {
                                         formData.append('logo', file);
                                         
                                         try {
-                                          const res = await fetch('/api/upload/publication-logo', {
+                                          const res = await apiFetch('/api/upload/publication-logo', {
                                             method: 'POST',
                                             credentials: 'include',
                                             body: formData

--- a/client/src/pages/admin/publications-manager.tsx
+++ b/client/src/pages/admin/publications-manager.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import { queryClient } from '@/lib/queryClient';
+import { apiFetch } from '@/lib/apiFetch';
 import { Publication, InsertPublication, Opportunity } from '@shared/schema';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -77,7 +78,7 @@ export default function PublicationsManager() {
   const { data: publications, isLoading, isError } = useQuery({
     queryKey: ['/api/publications'],
     queryFn: async () => {
-      const response = await fetch('/api/publications');
+      const response = await apiFetch('/api/publications');
       if (!response.ok) {
         throw new Error('Failed to fetch publications');
       }
@@ -89,7 +90,7 @@ export default function PublicationsManager() {
   const { data: opportunities, isLoading: isLoadingOpportunities } = useQuery({
     queryKey: ['/api/admin/opportunities'],
     queryFn: async () => {
-      const response = await fetch('/api/admin/opportunities');
+      const response = await apiFetch('/api/admin/opportunities');
       if (!response.ok) {
         throw new Error('Failed to fetch opportunities');
       }
@@ -159,7 +160,7 @@ export default function PublicationsManager() {
       const formData = new FormData();
       formData.append('logo', file);
       
-      const response = await fetch('/api/upload/publication-logo', {
+      const response = await apiFetch('/api/upload/publication-logo', {
         method: 'POST',
         body: formData,
       });
@@ -181,7 +182,7 @@ export default function PublicationsManager() {
   // Create publication mutation
   const createMutation = useMutation({
     mutationFn: async (publication: InsertPublication) => {
-      const response = await fetch('/api/admin/publications', {
+      const response = await apiFetch('/api/admin/publications', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -219,7 +220,7 @@ export default function PublicationsManager() {
   // Update publication mutation
   const updateMutation = useMutation({
     mutationFn: async ({ id, data }: { id: number; data: Partial<Publication> }) => {
-      const response = await fetch(`/api/admin/publications/${id}`, {
+      const response = await apiFetch(`/api/admin/publications/${id}`, {
         method: 'PATCH',
         headers: {
           'Content-Type': 'application/json',
@@ -258,7 +259,7 @@ export default function PublicationsManager() {
   // Delete publication mutation
   const deleteMutation = useMutation({
     mutationFn: async (id: number) => {
-      const response = await fetch(`/api/admin/publications/${id}`, {
+      const response = await apiFetch(`/api/admin/publications/${id}`, {
         method: 'DELETE',
       });
       
@@ -386,7 +387,7 @@ export default function PublicationsManager() {
   const { data: allPitches, isLoading: isLoadingPitches } = useQuery({
     queryKey: ['/api/admin/pitches'],
     queryFn: async () => {
-      const response = await fetch('/api/admin/pitches');
+      const response = await apiFetch('/api/admin/pitches');
       if (!response.ok) {
         throw new Error('Failed to fetch pitches');
       }

--- a/client/src/pages/admin/users-manager.tsx
+++ b/client/src/pages/admin/users-manager.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useToast } from "@/hooks/use-toast";
 import { apiRequest } from "@/lib/queryClient";
+import { apiFetch } from "@/lib/apiFetch";
 import { 
   Card, 
   CardContent, 
@@ -535,7 +536,7 @@ export default function UsersManager() {
                       className="flex items-center"
                       onClick={async () => {
                         try {
-                          const response = await fetch(`/api/admin/regenerate-agreements?userId=${selectedUser.id}`, {
+                          const response = await apiFetch(`/api/admin/regenerate-agreements?userId=${selectedUser.id}`, {
                             method: 'POST',
                           });
                           

--- a/client/src/pages/auth-page.tsx
+++ b/client/src/pages/auth-page.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { apiFetch } from "@/lib/apiFetch";
 import { Link, useLocation } from "wouter";
 import { z } from "zod";
 import { useForm } from "react-hook-form";
@@ -351,7 +352,7 @@ function RegisterForm() {
       ) {
         setPending((p) => ({ ...p, [field]: true }));
         setUniqueError((e) => ({ ...e, [field]: "" }));
-        fetch(`/api/users/check-unique?field=${field}&value=${encodeURIComponent(value)}`)
+        apiFetch(`/api/users/check-unique?field=${field}&value=${encodeURIComponent(value)}`)
           .then((res) => res.json())
           .then((data) => {
             setUnique((u) => ({ ...u, [field]: data.unique }));

--- a/client/src/pages/opportunities.tsx
+++ b/client/src/pages/opportunities.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { apiFetch } from '@/lib/apiFetch';
 import { useLocation } from 'wouter';
 import { Search, Filter, SlidersHorizontal, Loader2 } from 'lucide-react';
 import { Input } from '@/components/ui/input';
@@ -37,7 +38,7 @@ export default function OpportunitiesPage() {
   useEffect(() => {
     const fetchOpportunities = async () => {
       try {
-        const response = await fetch('/api/opportunities');
+        const response = await apiFetch('/api/opportunities');
         
         if (!response.ok) {
           throw new Error('Failed to fetch opportunities');

--- a/client/src/pages/payment-success.tsx
+++ b/client/src/pages/payment-success.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from "react";
+import { apiFetch } from "@/lib/apiFetch";
 import { useLocation, Link } from "wouter";
 import { useAuth } from "@/hooks/use-auth";
 import { Button } from "@/components/ui/button";
@@ -17,7 +18,7 @@ export default function PaymentSuccess() {
     // Mark user as having premium access
     const updateUserStatus = async () => {
       try {
-        await fetch(`/api/users/${user.id}/update-premium-status`, {
+        await apiFetch(`/api/users/${user.id}/update-premium-status`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json'

--- a/client/src/pages/profile-setup.tsx
+++ b/client/src/pages/profile-setup.tsx
@@ -6,6 +6,7 @@ import { useLocation } from 'wouter';
 import { useToast } from '@/hooks/use-toast';
 import { useAuth } from '@/hooks/use-auth';
 import { apiRequest, queryClient } from '@/lib/queryClient';
+import { apiFetch } from '@/lib/apiFetch';
 import { insertUserSchema } from '@shared/schema';
 import { SignupWizard } from '@/components/signup/SignupWizard';
 
@@ -185,7 +186,7 @@ export default function ProfileSetup() {
         const formData = new FormData();
         formData.append('avatar', avatarFile);
         
-        const response = await fetch(`/api/users/${user.id}/avatar`, {
+        const response = await apiFetch(`/api/users/${user.id}/avatar`, {
           method: 'POST',
           body: formData,
         });

--- a/client/src/pages/subscription-redirect.tsx
+++ b/client/src/pages/subscription-redirect.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { apiFetch } from "@/lib/apiFetch";
 import { useLocation } from "wouter";
 import { Button } from "@/components/ui/button";
 
@@ -16,7 +17,7 @@ export default function SubscriptionRedirect() {
     }
 
     // Get the checkout URL and redirect
-    fetch(`/api/get-checkout-url?session_id=${sessionId}`)
+    apiFetch(`/api/get-checkout-url?session_id=${sessionId}`)
       .then(response => {
         if (!response.ok) {
           throw new Error("Failed to get checkout URL");

--- a/client/src/pages/subscription-success.tsx
+++ b/client/src/pages/subscription-success.tsx
@@ -4,6 +4,7 @@ import { useToast } from '@/hooks/use-toast';
 import { Button } from '@/components/ui/button';
 import { CheckCircle2, Loader2 } from 'lucide-react';
 import { apiRequest } from '@/lib/queryClient';
+import { apiFetch } from '@/lib/apiFetch';
 
 export default function SubscriptionSuccess() {
   const [, navigate] = useLocation();
@@ -53,7 +54,7 @@ export default function SubscriptionSuccess() {
         console.log('Verifying payment with data:', { sessionId, paymentIntentId });
         
         // Check if user is authenticated first
-        const userResponse = await fetch('/api/user');
+        const userResponse = await apiFetch('/api/user');
         console.log('User auth check response:', userResponse.status);
         
         if (!userResponse.ok) {

--- a/client/src/store/opportunity-store.ts
+++ b/client/src/store/opportunity-store.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { Opportunity, PriceTick, BidInfo } from '@shared/types/opportunity';
 import { generatePriceHistory, sampleOpportunities } from '@/lib/fixtures/opportunities';
+import { apiFetch } from '@/lib/apiFetch';
 
 interface OpportunityState {
   // Current selected opportunity
@@ -41,7 +42,7 @@ const useOpportunityStore = create<OpportunityState>((set, get) => ({
     
     try {
       // Fetch the opportunity from the API
-      const response = await fetch(`/api/opportunities/${opportunityId}`, {
+      const response = await apiFetch(`/api/opportunities/${opportunityId}`, {
         credentials: 'include',
         headers: {
           'Cache-Control': 'no-cache',
@@ -74,7 +75,7 @@ const useOpportunityStore = create<OpportunityState>((set, get) => ({
     try {
       // Try to fetch price history from API
       try {
-        const response = await fetch(`/api/opportunities/${opportunityId}/price-history`, {
+        const response = await apiFetch(`/api/opportunities/${opportunityId}/price-history`, {
           credentials: 'include'
         });
         
@@ -129,7 +130,7 @@ const useOpportunityStore = create<OpportunityState>((set, get) => ({
     try {
       // Try to fetch bid info from API
       try {
-        const response = await fetch(`/api/opportunities/${opportunityId}/bid-info`, {
+        const response = await apiFetch(`/api/opportunities/${opportunityId}/bid-info`, {
           credentials: 'include'
         });
         
@@ -176,7 +177,7 @@ const useOpportunityStore = create<OpportunityState>((set, get) => ({
       // Submit the bid to the API
       console.log('Submitting bid:', { opportunityId, bidAmount, pitch, paymentIntentId });
       
-      const response = await fetch('/api/pitches', {
+      const response = await apiFetch('/api/pitches', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json'

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -5,6 +5,7 @@ import session from "express-session";
 import { hashPassword, comparePasswords } from "./utils/passwordUtils";
 import { storage } from "./storage";
 import { User as SelectUser } from "@shared/schema";
+import { ensureAuth } from './middleware/ensureAuth';
 import { z } from "zod";
 import path from "path";
 import fs from "fs";
@@ -137,19 +138,15 @@ export function setupAuth(app: Express) {
     });
   });
 
-  app.get("/api/user", (req, res) => {
-    if (!req.isAuthenticated()) return res.status(401).json({ message: "Not authenticated" });
+  app.get("/api/user", ensureAuth, (req, res) => {
     // Return user without password
     const { password, ...userWithoutPassword } = req.user as SelectUser;
     res.json(userWithoutPassword);
   });
 
   // Add PATCH endpoint for user profile updates
-  app.patch("/api/user", async (req, res, next) => {
+  app.patch("/api/user", ensureAuth, async (req, res, next) => {
     try {
-      if (!req.isAuthenticated()) {
-        return res.status(401).json({ message: "Not authenticated" });
-      }
       
       const userId = req.user.id;
       

--- a/server/middleware/ensureAuth.ts
+++ b/server/middleware/ensureAuth.ts
@@ -1,0 +1,15 @@
+import { Request, Response, NextFunction } from 'express';
+
+/**
+ * Middleware that ensures the request is authenticated via
+ * either Passport session or JWT-based auth. It relies on the
+ * `jwtAuth` middleware having already attached `req.user` when
+ * a valid token is supplied.
+ */
+export function ensureAuth(req: Request, res: Response, next: NextFunction) {
+  if (req.user) return next();
+  if (typeof (req as any).isAuthenticated === 'function' && (req as any).isAuthenticated()) {
+    return next();
+  }
+  return res.status(401).json({ message: 'Unauthorized' });
+}

--- a/server/middleware/jwtAuth.ts
+++ b/server/middleware/jwtAuth.ts
@@ -1,0 +1,36 @@
+import { Request, Response, NextFunction } from 'express';
+import jwt from 'jsonwebtoken';
+import { getDb } from '../db';
+import { users } from '@shared/schema';
+import { eq } from 'drizzle-orm';
+
+/**
+ * Middleware to authenticate requests using a JWT token.
+ * If a valid token is present in the Authorization header,
+ * the corresponding user is loaded and attached to `req.user`.
+ * This allows existing `req.isAuthenticated()` checks to work
+ * even without a session.
+ */
+export async function jwtAuth(req: Request, _res: Response, next: NextFunction) {
+  if (req.user) return next();
+
+  const authHeader = req.headers['authorization'];
+  const token = authHeader?.startsWith('Bearer ')
+    ? authHeader.slice(7)
+    : undefined;
+
+  if (!token) return next();
+
+  try {
+    const payload = jwt.verify(token, process.env.JWT_SECRET || 'quotebid_secret') as { id: number };
+    const [user] = await getDb().select().from(users).where(eq(users.id, payload.id));
+    if (user) {
+      // Assign user so `req.isAuthenticated()` returns true
+      (req as any).user = user;
+    }
+  } catch (err) {
+    // Ignore invalid token
+  }
+
+  next();
+}


### PR DESCRIPTION
## Summary
- add new `ensureAuth` middleware to handle JWT or session auth
- include middleware on auth routes
- centralize API calls through new `apiFetch`
- fix dev websocket port for login flow

## Testing
- `npm test` *(fails: jest not found)*