### PR TITLE
Fix signup auth and pdf upload

### DIFF
--- a/CODEX-CHEATSHEET.md
+++ b/CODEX-CHEATSHEET.md
@@ -28,6 +28,7 @@ STRIPE_SECRET=sk_test_•••
 # Other required variables
 NODE_ENV=development
 SESSION_SECRET=local_development_secret
+JWT_SECRET=quotebid_secret
 ```
 
 You can use the provided script to generate a basic .env file:

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -143,6 +143,7 @@ export function setupAuth(app: Express) {
           process.env.JWT_SECRET || 'quotebid_secret',
           { expiresIn: '7d' }
         );
+        res.cookie('token', token, { httpOnly: true, sameSite: 'lax' });
         res.status(200).json({ success: true, user: userWithoutPassword, token });
       });
     })(req, res, next);
@@ -151,6 +152,7 @@ export function setupAuth(app: Express) {
   app.post("/api/logout", (req, res, next) => {
     req.logout((err) => {
       if (err) return next(err);
+      res.clearCookie('token');
       res.sendStatus(200);
     });
   });

--- a/server/middleware/jwtAuth.ts
+++ b/server/middleware/jwtAuth.ts
@@ -3,6 +3,7 @@ import jwt from 'jsonwebtoken';
 import { getDb } from '../db';
 import { users } from '@shared/schema';
 import { eq } from 'drizzle-orm';
+import cookie from 'cookie';
 
 /**
  * Middleware to authenticate requests using a JWT token.
@@ -15,9 +16,14 @@ export async function jwtAuth(req: Request, _res: Response, next: NextFunction) 
   if (req.user) return next();
 
   const authHeader = req.headers['authorization'];
-  const token = authHeader?.startsWith('Bearer ')
+  let token = authHeader?.startsWith('Bearer ')
     ? authHeader.slice(7)
     : undefined;
+
+  if (!token && req.headers.cookie) {
+    const cookies = cookie.parse(req.headers.cookie);
+    token = cookies.token;
+  }
 
   if (!token) return next();
 

--- a/server/middleware/pdfUpload.ts
+++ b/server/middleware/pdfUpload.ts
@@ -1,0 +1,32 @@
+import multer from 'multer';
+import path from 'path';
+import fs from 'fs';
+
+// Directory to store uploaded agreement PDFs
+const agreementsDir = path.join(process.cwd(), 'uploads', 'agreements');
+if (!fs.existsSync(agreementsDir)) {
+  fs.mkdirSync(agreementsDir, { recursive: true });
+}
+
+const storage = multer.diskStorage({
+  destination: (_req, _file, cb) => cb(null, agreementsDir),
+  filename: (_req, file, cb) => {
+    const uniqueSuffix = Date.now() + '-' + Math.round(Math.random() * 1e9);
+    const ext = path.extname(file.originalname);
+    cb(null, `${uniqueSuffix}${ext}`);
+  },
+});
+
+const pdfUpload = multer({
+  storage,
+  fileFilter: (_req, file, cb) => {
+    if (file.mimetype === 'application/pdf') {
+      cb(null, true);
+    } else {
+      cb(new Error('Only PDF files are allowed'));
+    }
+  },
+  limits: { fileSize: 20 * 1024 * 1024 }, // 20MB
+});
+
+export default pdfUpload;

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -22,6 +22,7 @@ import { enforceOnboarding } from "./middleware/enforceOnboarding";
 import { jwtAuth } from "./middleware/jwtAuth";
 import { ensureAuth } from "./middleware/ensureAuth";
 import upload from './middleware/upload';
+import pdfUpload from './middleware/pdfUpload';
 import path from 'path';
 import fs from 'fs';
 import { saveAgreementPDF, regenerateAgreementsPDF, createAgreementPDF, generateProfessionalPDF } from './pdf-utils';
@@ -252,7 +253,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   app.post('/api/generate-pdf', handleGeneratePDF);
   
   // Upload signed agreement
-  app.post('/api/upload-agreement', upload.single('pdf'), handleSignupAgreementUpload);
+  app.post('/api/upload-agreement', pdfUpload.single('pdf'), handleSignupAgreementUpload);
   
   // Set up regular user authentication
   setupAuth(app);


### PR DESCRIPTION
## Summary
- add JWT_SECRET variable instructions
- send cookie on login and clear cookie on logout
- read JWT from cookie in middleware
- allow uploading PDF agreements
- route uses PDF upload middleware

## Testing
- `npm test` *(fails: jest not found)*