### PR TITLE
Add /register route for signup wizard

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -18,6 +18,7 @@ import SubscriptionSuccess from "@/pages/subscription-success";
 import SubscriptionRedirect from "@/pages/subscription-redirect";
 import ProfileSetup from "@/pages/profile-setup";
 import SignupWizard from "@/pages/SignupWizard";
+import RegisterPage from "@/pages/register";
 import AuthPage from "@/pages/auth-page";
 import Account from "@/pages/account";
 // Profile page removed as requested
@@ -124,6 +125,7 @@ function Router() {
         <Route path="/admin/login-test" component={AdminLoginTest} />
         <Route path="/admin/create-admin" component={AdminCreateAdmin} />
         <Route path="/signup-wizard" component={SignupWizard} />
+        <Route path="/register" component={RegisterPage} />
         
         {/* Routes that require authentication */}
         <ProtectedRoute path="/agreement" component={() => <Agreement />} />

--- a/client/src/components/signup/SignupWizard.tsx
+++ b/client/src/components/signup/SignupWizard.tsx
@@ -27,7 +27,15 @@ export function SignupWizard({ children }: SignupWizardProps) {
     : '';
 
   const enforceLocation = () => {
-    const highest = Number(localStorage.getItem('signup_highest_step') || String(currentStep));
+    // Allow the wizard to be used on the standalone /register route without
+    // forcing a redirect to /auth. Only enforce the legacy query params when
+    // the user is already on the /auth page.
+    if (window.location.pathname.startsWith('/register')) {
+      return;
+    }
+    const highest = Number(
+      localStorage.getItem('signup_highest_step') || String(currentStep)
+    );
     const url = new URL(window.location.href);
     const tab = url.searchParams.get('tab');
     const stepParam = Number(url.searchParams.get('step') || '1');

--- a/client/src/pages/SignupWizard.tsx
+++ b/client/src/pages/SignupWizard.tsx
@@ -48,6 +48,12 @@ function SignupWizardContent() {
 
   // Handle browser back button and prevent back navigation
   useEffect(() => {
+    // When rendering on the standalone /register page we don't need to enforce
+    // the legacy query params used by /auth. This allows the new sign up flow to
+    // work without redirecting.
+    if (window.location.pathname.startsWith('/register')) {
+      return;
+    }
     const handlePopState = (event: PopStateEvent) => {
       event.preventDefault();
       const highestStep = Number(localStorage.getItem('signup_highest_step') || '1');

--- a/client/src/pages/register.tsx
+++ b/client/src/pages/register.tsx
@@ -1,0 +1,5 @@
+import SignupWizard from './SignupWizard';
+
+export default function RegisterPage() {
+  return <SignupWizard />;
+}


### PR DESCRIPTION
## Summary
- create `register.tsx` page that renders `SignupWizard`
- expose new `/register` route alongside existing `/signup-wizard`
- allow `SignupWizard` to work on the `/register` path without forcing `/auth` redirect

## Testing
- `npm run check` *(fails: jest, node, vite/client types not found)*
- `npm test` *(fails: jest not found)*