### PR TITLE
Improve signup stage handling

### DIFF
--- a/client/src/contexts/SignupWizardContext.tsx
+++ b/client/src/contexts/SignupWizardContext.tsx
@@ -12,6 +12,7 @@ const SignupWizardContext = createContext<SignupWizardContextType | undefined>(u
 
 export function SignupWizardProvider({ children }: { children: ReactNode }) {
   const [currentStage, setCurrentStage] = useState<SignupStage>('payment');
+  const STAGE_ORDER: SignupStage[] = ['payment', 'profile', 'ready'];
   const [email, setEmail] = useState<string | null>(null);
 
   useEffect(() => {
@@ -64,7 +65,19 @@ export function SignupWizardProvider({ children }: { children: ReactNode }) {
   };
 
   const setStage = (stage: SignupStage) => {
-    setCurrentStage(stage);
+    if (!STAGE_ORDER.includes(stage)) {
+      console.warn(`[SignupWizardContext] Invalid stage: ${stage}`);
+      return;
+    }
+    setCurrentStage(prev => {
+      const prevIndex = STAGE_ORDER.indexOf(prev);
+      const newIndex = STAGE_ORDER.indexOf(stage);
+      if (newIndex < prevIndex) {
+        console.warn(`[SignupWizardContext] Attempted to regress stage from ${prev} to ${stage}`);
+        return prev;
+      }
+      return stage;
+    });
     
     // Update highest step in localStorage
     const stageToStep = (stage: SignupStage) => {

--- a/client/src/contexts/__tests__/SignupWizardContext.test.tsx
+++ b/client/src/contexts/__tests__/SignupWizardContext.test.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { renderHook, act } from '@testing-library/react';
+import { SignupWizardProvider, useSignupWizard } from '../SignupWizardContext';
+
+function setup() {
+  const wrapper: React.FC<{children: React.ReactNode}> = ({ children }) => (
+    <SignupWizardProvider>{children}</SignupWizardProvider>
+  );
+  return renderHook(() => useSignupWizard(), { wrapper });
+}
+
+describe('SignupWizardContext setStage validation', () => {
+  it('allows advancing to a valid next stage', () => {
+    const { result } = setup();
+    act(() => result.current.setStage('profile'));
+    expect(result.current.currentStage).toBe('profile');
+  });
+
+  it('prevents regressing to a previous stage', () => {
+    const { result } = setup();
+    act(() => result.current.setStage('profile'));
+    act(() => result.current.setStage('payment'));
+    expect(result.current.currentStage).toBe('profile');
+  });
+
+  it('ignores invalid stage values', () => {
+    const { result } = setup();
+    act(() => result.current.setStage('ready'));
+    // @ts-ignore
+    act(() => result.current.setStage('bogus'));
+    expect(result.current.currentStage).toBe('ready');
+  });
+});

--- a/client/src/lib/signup-wizard.ts
+++ b/client/src/lib/signup-wizard.ts
@@ -142,3 +142,17 @@ export function getRedirectUrlForStage(stage: SignupStage): string {
       return '/payment';
   }
 }
+
+/**
+ * Determine the next application route based on a signup stage
+ */
+export function nextRouteForStage(stage: SignupStage): string {
+  switch (stage) {
+    case 'payment':
+      return '/profile-setup';
+    case 'profile':
+      return '/opportunities';
+    default:
+      return '/opportunities';
+  }
+}

--- a/server/routes/signupStage.ts
+++ b/server/routes/signupStage.ts
@@ -60,57 +60,30 @@ const router = Router();
 const VALID_STAGES = ['payment', 'profile', 'ready', 'legacy'];
 
 export async function startSignup(req: Request, res: Response) {
- um7klu-codex/fix-ui-connection-for-sign-up-form
-  const {
-    email,
-    username,
-    phone,
-    password,
-    name,
-    industry,
-    company,
-  } = req.body as {
-
   const { email, username, phone, password, name, companyName, industry, hasAgreedToTerms } = req.body as {
-new-signup-process
     email: string;
     username: string;
     phone: string;
     password: string;
     name?: string;
-um7klu-codex/fix-ui-connection-for-sign-up-form
-    industry?: string;
-    company?: string;
-  };
-  if (!email || !username || !phone || !password) {
-    return res.status(400).json({ message: 'Missing required fields' });
-  }
-
-  const normalizedUsername = username.toLowerCase();
-  if (!/^[a-z0-9]+$/.test(normalizedUsername)) {
-    return res.status(400).json({
-      message: 'Username must contain only lowercase letters and numbers',
-    });
-  }
-
-=======
     companyName?: string;
     industry?: string;
     hasAgreedToTerms: boolean;
   };
+
   if (!email || !username || !phone || !password || !hasAgreedToTerms) {
     return res.status(400).json({ message: 'Missing required fields' });
   }
-  // Validate username format
+
   const usernameRegex = /^[a-z0-9]{4,30}$/;
   const normalizedUsername = username.toLowerCase().trim();
   if (!usernameRegex.test(normalizedUsername)) {
-    return res.status(400).json({ 
+    return res.status(400).json({
       message: 'Username must be 4-30 characters, lowercase letters and numbers only',
       field: 'username'
     });
   }
- new-signup-process
+
   const db = getDb();
   // Check for existing user by email/username/phone
   const existing = await db
@@ -135,16 +108,7 @@ um7klu-codex/fix-ui-connection-for-sign-up-form
   await db.transaction(async (tx) => {
     const inserted = await tx.insert(users).values({
       email,
- um7klu-codex/fix-ui-connection-for-sign-up-form
       username: normalizedUsername,
-      fullName: name || normalizedUsername,
-      phone_number: phone,
-      company_name: company,
-      industry,
-      password: hashed,
-      signup_stage: 'payment',
-
-      username: username.toLowerCase(), // Ensure username is stored in lowercase
       fullName: name || username,
       phone_number: phone,
       company_name: companyName,
@@ -152,15 +116,11 @@ um7klu-codex/fix-ui-connection-for-sign-up-form
       password: hashed,
       signup_stage: 'payment',
       hasAgreedToTerms: true
- new-signup-process
     }).returning({ id: users.id });
     newId = inserted[0].id as number;
     await tx.insert(signupState).values({ userId: newId!, status: 'payment' });
   });
- um7klu-codex/fix-ui-connection-for-sign-up-form
 
-
-new-signup-process
   return res.status(201).json({ userId: newId, step: 'payment' });
 }
 


### PR DESCRIPTION
## Summary
- cleanup and normalize startSignup API
- add stage regression protection and validation in SignupWizardContext
- expose `nextRouteForStage` helper
- add unit tests for the context stage logic

## Testing
- `npm test` *(fails: jest not found)*